### PR TITLE
Fix #3 - change file extension from .pem to .crt

### DIFF
--- a/tasks/distribution/Linux/certificate.yml
+++ b/tasks/distribution/Linux/certificate.yml
@@ -24,7 +24,7 @@
 - name: 'linux : {{ install_item.name }} - Copy certificate content'
   copy:
     content: '{{ install_item.content }}'
-    dest: '{{ ca_certificates_path }}/{{ install_item.name }}.pem'
+    dest: '{{ ca_certificates_path }}/{{ install_item.name }}.crt'
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
When specifying a certificate inline (with `content`) the file was saved as a `.pem` and subsequently not imported by `/usr/sbin/update-ca-certificates`.

I encountered this issue myself on 20.04.1 LTS (Focal Fossa).

This fixes that so all certificates are saved as a `.crt` now (fix #3)