### PR TITLE
Support REDOS (fork of RedHat)

### DIFF
--- a/vars/RED.yml
+++ b/vars/RED.yml
@@ -1,0 +1,12 @@
+---
+# vars file for arillso.ca-certificates
+
+#
+# Defaults for RedHat-based Linux systems
+#
+
+# Directory where certificates should be placed
+ca_certificates_path: /etc/pki/ca-trust/source/anchors
+
+# Command to run after adding new certificates
+ca_certificates_handler: /usr/bin/update-ca-trust extract


### PR DESCRIPTION
Ansible detects distribution of REDOS [1] as RED. It fails to find correct variables. 

This commit add support of REDOS for this role. Change is simple: byte-to-byte copy of variables for Red Hat. 
It works at least for me on REDOS 7.3.1

1: https://www.red-soft.ru/en/main_products.html#redos